### PR TITLE
Help: Point to the Overview file

### DIFF
--- a/ReaCollider.quark
+++ b/ReaCollider.quark
@@ -2,7 +2,7 @@
   name: "ReaCollider",
   summary: "Generate Reaper Projects from SuperCollider",
   version: "0.001",
-  schelp: "ReaCollider.schelp",
+  schelp: "Overview/ReaCollider",
   dependencies: nil,
   license: "GNU GPL v3.0",
   copyright: "James Bradbury, Mads Kjeldgaard",


### PR DESCRIPTION
In `Quarks.gui` "Open help" didn't work. This fixes the issue and "Open help" opens the Overview file.